### PR TITLE
Cyclic Bloodmoon

### DIFF
--- a/src/main/java/lumien/randomthings/Configuration/RTConfiguration.java
+++ b/src/main/java/lumien/randomthings/Configuration/RTConfiguration.java
@@ -29,6 +29,8 @@ public class RTConfiguration {
     public static Property decayFuzz;
 
     public static Property bloodMoon_chance;
+    public static Property bloodMoon_cycle;
+
     public static Property bloodMoon_spawnSpeed;
     public static Property bloodMoon_spawnLimitMult;
     public static Property bloodMoon_spawnRange;
@@ -129,6 +131,11 @@ public class RTConfiguration {
                 "BloodMoonChance",
                 0.05,
                 "The chance of a bloodmoon happening (0=Never;1=Every night;0.05=5% of all nights)");
+        bloodMoon_cycle = config.get(
+                "Settings",
+                "BloodMoonCycle",
+                0,
+                "Blood moon happens cyclically every X days (set to 0 to disable it)");
         bloodMoon_noSleep = config.get(
                 "Settings",
                 "BloodMoonNoSleep",
@@ -251,6 +258,7 @@ public class RTConfiguration {
         Settings.DECAY_SPEED = decaySpeed.getInt();
         Settings.DECAY_FUZZ = decayFuzz.getInt();
         Settings.BLOODMOON_CHANCE = (float) bloodMoon_chance.getDouble(0.05);
+        Settings.BLOODMOON_CYCLE = bloodMoon_cycle.getInt(0);
         Settings.BLOODMOON_SPAWNLIMIT_MULTIPLIER = bloodMoon_spawnLimitMult.getInt(3);
         Settings.BLOODMOON_SPAWNRANGE = bloodMoon_spawnRange.getInt(4);
         Settings.BLOODMOON_SPAWNSPEED = bloodMoon_spawnSpeed.getInt(3);

--- a/src/main/java/lumien/randomthings/Configuration/Settings.java
+++ b/src/main/java/lumien/randomthings/Configuration/Settings.java
@@ -34,6 +34,8 @@ public class Settings {
     public static int BLOODMOON_SPAWNRANGE = 4; // 24
     public static boolean BLOODMOON_NOSLEEP = true;
     public static float BLOODMOON_CHANCE = 0.05f;
+    public static int BLOODMOON_CYCLE = 0;
+
     public static boolean BLOODMOON_VANISH = false;
     public static boolean BLOODMOON_RESPECT_GAMERULE = true;
     public static boolean BLOODMOON_MESSAGE = true;

--- a/src/main/java/lumien/randomthings/Handler/Bloodmoon/ServerBloodmoonHandler.java
+++ b/src/main/java/lumien/randomthings/Handler/Bloodmoon/ServerBloodmoonHandler.java
@@ -48,6 +48,8 @@ public class ServerBloodmoonHandler extends WorldSavedData {
     public void endWorldTick(World world) {
         if (world.provider.dimensionId == 0) {
             int time = (int) (world.getWorldTime() % 24000);
+            int date = (int) Math.floor(world.getWorldTime() / 24000d);
+
             if (bloodMoon) {
                 if (!Settings.BLOODMOON_RESPECT_GAMERULE
                         || world.getGameRules().getGameRuleBooleanValue("doMobSpawning")) {
@@ -65,7 +67,7 @@ public class ServerBloodmoonHandler extends WorldSavedData {
                 }
             } else {
                 if (time == 12000) {
-                    if (forceBloodMoon || Math.random() < Settings.BLOODMOON_CHANCE) {
+                    if (forceBloodMoon || isBloodMoonCycle(date) || Math.random() < Settings.BLOODMOON_CHANCE) {
                         forceBloodMoon = false;
                         setBloodmoon(true);
 
@@ -113,5 +115,12 @@ public class ServerBloodmoonHandler extends WorldSavedData {
 
     public boolean isBloodmoonScheduled() {
         return forceBloodMoon;
+    }
+
+    public boolean isBloodMoonCycle(int day) {
+        if (Settings.BLOODMOON_CYCLE > 0 && day > 0) {
+            return day % Settings.BLOODMOON_CYCLE == 0;
+        }
+        return false;
     }
 }


### PR DESCRIPTION
Add configuration to make Blood Moons cyclical (disabled by default).

Every X days (configurable) a blood moon will rise.
This  works fine in conjunction with the current chance system but it would likely result in too frequent blood moons.