### PR TITLE
Allow planting plains-type plants on tilled or untilled fertilized dirt

### DIFF
--- a/src/main/java/lumien/randomthings/Blocks/BlockFertilizedDirt.java
+++ b/src/main/java/lumien/randomthings/Blocks/BlockFertilizedDirt.java
@@ -88,9 +88,10 @@ public class BlockFertilizedDirt extends BlockBase {
         switch (plantType) {
             case Desert:
             case Beach:
-            case Plains:
             case Cave:
                 return !tilled;
+            case Plains:
+                return true;
             case Nether:
             case Water:
                 return false;


### PR DESCRIPTION
This fixes GTNewHorizons/GT-New-Horizons-Modpack#15649, which occurs because Pam's glowflowers present as crop-type as seeds but turn into plains-type when placed, causing them to be broken on the next block update. As far as I know, this shouldn't result in any substantial change in functionality, since you could already plant plains-type plants on untilled fertilized dirt. This also matches vanilla more closely; you can place plains-type plants on both dirt and farmland.