### PR TITLE
Fix bloodmoon code running in peaceful

### DIFF
--- a/src/main/java/lumien/randomthings/Handler/Bloodmoon/ServerBloodmoonHandler.java
+++ b/src/main/java/lumien/randomthings/Handler/Bloodmoon/ServerBloodmoonHandler.java
@@ -13,6 +13,7 @@ import net.minecraft.world.WorldSavedData;
 import net.minecraft.world.WorldServer;
 
 import lumien.randomthings.Configuration.Settings;
+import lumien.randomthings.Mixins.Minecraft.WorldAccessor;
 import lumien.randomthings.Network.Messages.MessageBloodmoon;
 import lumien.randomthings.Network.PacketHandler;
 
@@ -51,8 +52,8 @@ public class ServerBloodmoonHandler extends WorldSavedData {
             int date = (int) Math.floor(world.getWorldTime() / 24000d);
 
             if (bloodMoon) {
-                if (!Settings.BLOODMOON_RESPECT_GAMERULE
-                        || world.getGameRules().getGameRuleBooleanValue("doMobSpawning")) {
+                boolean spawnHostiles = ((WorldAccessor) world).isSpawnHostileMobs();
+                if (!Settings.BLOODMOON_RESPECT_GAMERULE || spawnHostiles) {
                     for (int i = 0; i < Settings.BLOODMOON_SPAWNSPEED; i++) {
                         bloodMoonSpawner.findChunksForSpawning(
                                 (WorldServer) world,

--- a/src/main/java/lumien/randomthings/Mixins/Minecraft/WorldAccessor.java
+++ b/src/main/java/lumien/randomthings/Mixins/Minecraft/WorldAccessor.java
@@ -1,0 +1,14 @@
+package lumien.randomthings.Mixins.Minecraft;
+
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(World.class)
+public interface WorldAccessor {
+
+    @Accessor
+    boolean isSpawnHostileMobs();
+
+}

--- a/src/main/java/lumien/randomthings/Mixins/Mixin.java
+++ b/src/main/java/lumien/randomthings/Mixins/Mixin.java
@@ -13,12 +13,13 @@ import lumien.randomthings.Configuration.VanillaChanges;
  */
 public enum Mixin {
 
-    ENTITYLIVING_ACCESSOR("EntityLivingAccessor", Side.BOTH, () -> true),
-    POTION_ACCESSOR("PotionAccessor", Side.BOTH, () -> true),
     BLOCK_LEAVES_BASE("MixinBlockLeavesBase", Side.BOTH, () -> VanillaChanges.FASTER_LEAVEDECAY),
+    ENTITYLIVING_ACCESSOR("EntityLivingAccessor", Side.BOTH, () -> true),
     ENTITY_RENDERER("MixinEntityRenderer", Side.CLIENT, () -> true),
     GUIVIDEOSETTINGS("MixinGuiVideoSettings", Side.CLIENT, () -> VanillaChanges.LOCKED_GAMMA),
     ITEM("MixinItem", Side.CLIENT, () -> true),
+    MINECRAFT_SERVER("WorldAccessor", Side.BOTH, () -> true),
+    POTION_ACCESSOR("PotionAccessor", Side.BOTH, () -> true),
     RENDER_GLOBAL("MixinRenderGlobal", Side.CLIENT, () -> true),
     WORLD("MixinWorld", Side.BOTH, () -> ConfigBlocks.wirelessLever);
 


### PR DESCRIPTION
The bloodmoon code checked for `world.getGameRules().getGameRuleBooleanValue("doMobSpawning")` which is still true when in peaceful difficulty. This is annoying because this code is very expensive and runs constantly when there is a bloodmoon.

To check if hostile mobs can spawn or not you need to check `World.spawnHostileMobs` which is a protected field so I added a mixin accessor.