### PR TITLE
Fix bloodmoon not checking gamerule

### DIFF
--- a/src/main/java/lumien/randomthings/Handler/Bloodmoon/ServerBloodmoonHandler.java
+++ b/src/main/java/lumien/randomthings/Handler/Bloodmoon/ServerBloodmoonHandler.java
@@ -53,7 +53,8 @@ public class ServerBloodmoonHandler extends WorldSavedData {
 
             if (bloodMoon) {
                 boolean spawnHostiles = ((WorldAccessor) world).isSpawnHostileMobs();
-                if (!Settings.BLOODMOON_RESPECT_GAMERULE || spawnHostiles) {
+                boolean doMobSpawning = world.getGameRules().getGameRuleBooleanValue("doMobSpawning");
+                if (!Settings.BLOODMOON_RESPECT_GAMERULE || spawnHostiles && doMobSpawning) {
                     for (int i = 0; i < Settings.BLOODMOON_SPAWNSPEED; i++) {
                         bloodMoonSpawner.findChunksForSpawning(
                                 (WorldServer) world,
@@ -62,7 +63,6 @@ public class ServerBloodmoonHandler extends WorldSavedData {
                                 world.getTotalWorldTime() % 20 == 0);
                     }
                 }
-
                 if (time >= 0 && time < 12000) {
                     setBloodmoon(false);
                 }

--- a/src/main/java/lumien/randomthings/Handler/Bloodmoon/ServerBloodmoonHandler.java
+++ b/src/main/java/lumien/randomthings/Handler/Bloodmoon/ServerBloodmoonHandler.java
@@ -54,7 +54,7 @@ public class ServerBloodmoonHandler extends WorldSavedData {
             if (bloodMoon) {
                 boolean spawnHostiles = ((WorldAccessor) world).isSpawnHostileMobs();
                 boolean doMobSpawning = world.getGameRules().getGameRuleBooleanValue("doMobSpawning");
-                if (!Settings.BLOODMOON_RESPECT_GAMERULE || spawnHostiles && doMobSpawning) {
+                if (!Settings.BLOODMOON_RESPECT_GAMERULE || (spawnHostiles && doMobSpawning)) {
                     for (int i = 0; i < Settings.BLOODMOON_SPAWNSPEED; i++) {
                         bloodMoonSpawner.findChunksForSpawning(
                                 (WorldServer) world,


### PR DESCRIPTION
In my previous PR I fixed the bloomoon algorithm that tried spawning mobs even if you are in peaceful, and in doing so I removed the check for the `doMobSpawning` gamerule. Turns out you need to check both...