### PR TITLE
Pause Bloodmoon for a couple of days after world creation

### DIFF
--- a/src/main/java/lumien/randomthings/Configuration/RTConfiguration.java
+++ b/src/main/java/lumien/randomthings/Configuration/RTConfiguration.java
@@ -30,6 +30,7 @@ public class RTConfiguration {
 
     public static Property bloodMoon_chance;
     public static Property bloodMoon_cycle;
+    public static Property bloodMoon_initial_pause;
 
     public static Property bloodMoon_spawnSpeed;
     public static Property bloodMoon_spawnLimitMult;
@@ -136,6 +137,11 @@ public class RTConfiguration {
                 "BloodMoonCycle",
                 0,
                 "Blood moon happens cyclically every X days (set to 0 to disable it)");
+        bloodMoon_initial_pause = config.get(
+                "Settings",
+                "BloodMoonInitialPause",
+                5,
+                "Stop bloodmoons from happening for the first X days after world creation").setMinValue(0);
         bloodMoon_noSleep = config.get(
                 "Settings",
                 "BloodMoonNoSleep",
@@ -259,6 +265,7 @@ public class RTConfiguration {
         Settings.DECAY_FUZZ = decayFuzz.getInt();
         Settings.BLOODMOON_CHANCE = (float) bloodMoon_chance.getDouble(0.05);
         Settings.BLOODMOON_CYCLE = bloodMoon_cycle.getInt(0);
+        Settings.BLOODMOON_INITIAL_PAUSE = bloodMoon_initial_pause.getInt(5);
         Settings.BLOODMOON_SPAWNLIMIT_MULTIPLIER = bloodMoon_spawnLimitMult.getInt(3);
         Settings.BLOODMOON_SPAWNRANGE = bloodMoon_spawnRange.getInt(4);
         Settings.BLOODMOON_SPAWNSPEED = bloodMoon_spawnSpeed.getInt(3);

--- a/src/main/java/lumien/randomthings/Configuration/Settings.java
+++ b/src/main/java/lumien/randomthings/Configuration/Settings.java
@@ -35,6 +35,7 @@ public class Settings {
     public static boolean BLOODMOON_NOSLEEP = true;
     public static float BLOODMOON_CHANCE = 0.05f;
     public static int BLOODMOON_CYCLE = 0;
+    public static int BLOODMOON_INITIAL_PAUSE = 5;
 
     public static boolean BLOODMOON_VANISH = false;
     public static boolean BLOODMOON_RESPECT_GAMERULE = true;

--- a/src/main/java/lumien/randomthings/Handler/Bloodmoon/ServerBloodmoonHandler.java
+++ b/src/main/java/lumien/randomthings/Handler/Bloodmoon/ServerBloodmoonHandler.java
@@ -71,7 +71,8 @@ public class ServerBloodmoonHandler extends WorldSavedData {
                 }
             } else {
                 if (time == 12000) {
-                    if (forceBloodMoon || isBloodMoonCycle(date) || Math.random() < Settings.BLOODMOON_CHANCE) {
+                    if (forceBloodMoon || (date >= Settings.BLOODMOON_INITIAL_PAUSE
+                            && (isBloodMoonCycle(date) || Math.random() < Settings.BLOODMOON_CHANCE))) {
                         forceBloodMoon = false;
                         setBloodmoon(true);
 

--- a/src/main/java/lumien/randomthings/Handler/Bloodmoon/ServerBloodmoonHandler.java
+++ b/src/main/java/lumien/randomthings/Handler/Bloodmoon/ServerBloodmoonHandler.java
@@ -46,43 +46,41 @@ public class ServerBloodmoonHandler extends WorldSavedData {
     }
 
     public void endWorldTick(World world) {
-        if (world.provider.dimensionId == 0) {
-            int time = (int) (world.getWorldTime() % 24000);
-            int date = (int) Math.floor(world.getWorldTime() / 24000d);
+        if (world.provider.dimensionId != 0) return;
 
-            if (bloodMoon) {
-                boolean spawnHostiles = ((WorldAccessor) world).isSpawnHostileMobs();
-                boolean doMobSpawning = world.getGameRules().getGameRuleBooleanValue("doMobSpawning");
-                if (!Settings.BLOODMOON_RESPECT_GAMERULE || (spawnHostiles && doMobSpawning)) {
-                    for (int i = 0; i < Settings.BLOODMOON_SPAWNSPEED; i++) {
-                        final SpawnerAnimals spawnerAnimals = ((WorldServerAccessor) world).getAnimalSpawner();
-                        final SpawnerAnimalsExt accessor = (SpawnerAnimalsExt) (Object) spawnerAnimals;
-                        accessor.rt$setBloodmoon(true);
-                        spawnerAnimals.findChunksForSpawning(
-                                (WorldServer) world,
-                                true,
-                                false,
-                                world.getTotalWorldTime() % 20 == 0);
-                        accessor.rt$setBloodmoon(false);
-                    }
-                }
-                if (time >= 0 && time < 12000) {
-                    setBloodmoon(false);
-                }
-            } else {
-                if (time == 12000) {
-                    if (forceBloodMoon || (date >= Settings.BLOODMOON_INITIAL_PAUSE
-                            && (isBloodMoonCycle(date) || Math.random() < Settings.BLOODMOON_CHANCE))) {
-                        forceBloodMoon = false;
-                        setBloodmoon(true);
+        int time = (int) (world.getWorldTime() % 24000);
+        int date = (int) Math.floor(world.getWorldTime() / 24000d);
 
-                        if (Settings.BLOODMOON_MESSAGE) {
-                            for (EntityPlayer player : ((List<EntityPlayer>) world.playerEntities)) {
-                                player.addChatMessage(
-                                        new ChatComponentTranslation("text.bloodmoon.notify")
-                                                .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
-                            }
-                        }
+        if (bloodMoon) {
+            boolean spawnHostiles = ((WorldAccessor) world).isSpawnHostileMobs();
+            boolean doMobSpawning = world.getGameRules().getGameRuleBooleanValue("doMobSpawning");
+            if (!Settings.BLOODMOON_RESPECT_GAMERULE || (spawnHostiles && doMobSpawning)) {
+                for (int i = 0; i < Settings.BLOODMOON_SPAWNSPEED; i++) {
+                    final SpawnerAnimals spawnerAnimals = ((WorldServerAccessor) world).getAnimalSpawner();
+                    final SpawnerAnimalsExt accessor = (SpawnerAnimalsExt) (Object) spawnerAnimals;
+                    accessor.rt$setBloodmoon(true);
+                    spawnerAnimals.findChunksForSpawning(
+                            (WorldServer) world,
+                            true,
+                            false,
+                            world.getTotalWorldTime() % 20 == 0);
+                    accessor.rt$setBloodmoon(false);
+                }
+            }
+            if (time >= 0 && time < 12000) {
+                setBloodmoon(false);
+            }
+        } else if (time == 12000) {
+            if (forceBloodMoon || (date >= Settings.BLOODMOON_INITIAL_PAUSE
+                    && (isBloodMoonCycle(date) || Math.random() < Settings.BLOODMOON_CHANCE))) {
+                forceBloodMoon = false;
+                setBloodmoon(true);
+
+                if (Settings.BLOODMOON_MESSAGE) {
+                    for (EntityPlayer player : ((List<EntityPlayer>) world.playerEntities)) {
+                        player.addChatMessage(
+                                new ChatComponentTranslation("text.bloodmoon.notify")
+                                        .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
                     }
                 }
             }


### PR DESCRIPTION
I saw a newcomer lamenting getting a Bloodmoon on their first night and I thought this is unnecessary, even if it's a rare occurrence. There is enough else going on during the first nights in GTNH that I think it's fine if Bloodmoons kicks in a little later.

This mainly affects singleplayer.

I have decided 5 days is a good value to wait until the Bloodmoon cycles can start, but we can change that in the config, of course.