### PR TITLE
Fix AdvancedItemCollector able to collect dead items

### DIFF
--- a/src/main/java/lumien/randomthings/TileEntities/TileEntityAdvancedItemCollector.java
+++ b/src/main/java/lumien/randomthings/TileEntities/TileEntityAdvancedItemCollector.java
@@ -149,6 +149,8 @@ public class TileEntityAdvancedItemCollector extends TileEntity {
                         }
 
                         for (EntityItem ei : items) {
+                            if (ei.isDead) continue;
+
                             if (inventory.getStackInSlot(0) == null
                                     || ItemFilter.matchesItem(inventory.getStackInSlot(0), ei.getEntityItem())) {
                                 ItemStack rest = TileEntityHopper.func_145889_a(


### PR DESCRIPTION
Causing it to process items it shouldn't process.

Tested in full pack 2.8.1