### PR TITLE
Fix spectre teleportation

### DIFF
--- a/src/main/java/lumien/randomthings/Handler/RTEventHandler.java
+++ b/src/main/java/lumien/randomthings/Handler/RTEventHandler.java
@@ -26,12 +26,9 @@ import net.minecraft.item.ItemDye;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.PotionEffect;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.ChatStyle;
 import net.minecraft.util.EnumChatFormatting;
-import net.minecraft.world.WorldProvider;
-import net.minecraft.world.WorldServer;
 import net.minecraftforge.client.event.EntityViewRenderEvent.FogColors;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderLivingEvent;
@@ -59,7 +56,6 @@ import cpw.mods.fml.client.event.ConfigChangedEvent.OnConfigChangedEvent;
 import cpw.mods.fml.common.eventhandler.Event.Result;
 import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
-import cpw.mods.fml.common.gameevent.PlayerEvent.PlayerChangedDimensionEvent;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import lumien.randomthings.Blocks.ModBlocks;
@@ -266,26 +262,6 @@ public class RTEventHandler {
         if (event.world.isRemote && VanillaChanges.LOCKED_GAMMA) {
             Minecraft.getMinecraft().gameSettings.setOptionFloatValue(GameSettings.Options.GAMMA, 0);
             Minecraft.getMinecraft().gameSettings.gammaSetting = 0;
-        }
-    }
-
-    @SubscribeEvent
-    public void changedDimension(PlayerChangedDimensionEvent event) {
-        if (event.toDim == Settings.SPECTRE_DIMENSON_ID) {
-            double movementFactor = 1;
-            EntityPlayer player = event.player;
-            WorldServer world = MinecraftServer.getServer().worldServerForDimension(event.fromDim);
-            if (world != null) {
-                WorldProvider provider = world.provider;
-                if (provider != null) {
-                    movementFactor = provider.getMovementFactor();
-                }
-            }
-            final NBTTagCompound nbt = player.getEntityData();
-            nbt.setInteger(RandomThingsNBTKeys.OLD_DIMENSION, event.fromDim);
-            nbt.setDouble(RandomThingsNBTKeys.OLD_POSX, player.posX / movementFactor);
-            nbt.setDouble(RandomThingsNBTKeys.OLD_POSY, player.posY);
-            nbt.setDouble(RandomThingsNBTKeys.OLD_POSZ, player.posZ / movementFactor);
         }
     }
 

--- a/src/main/java/lumien/randomthings/Handler/Spectre/SpectreHandler.java
+++ b/src/main/java/lumien/randomthings/Handler/Spectre/SpectreHandler.java
@@ -19,11 +19,9 @@ import net.minecraft.world.WorldServer;
 
 import org.apache.logging.log4j.Level;
 
-import lumien.randomthings.Blocks.ModBlocks;
 import lumien.randomthings.Configuration.Settings;
 import lumien.randomthings.Library.PotionEffects;
 import lumien.randomthings.Library.RandomThingsNBTKeys;
-import lumien.randomthings.Library.WorldUtils;
 import lumien.randomthings.Mixins.early.EntityAccessor;
 import lumien.randomthings.Network.Messages.MessageSpectreData;
 import lumien.randomthings.Network.PacketHandler;
@@ -61,39 +59,26 @@ public class SpectreHandler extends WorldSavedData {
                 WorldServer spectreWorld = MinecraftServer.getServer()
                         .worldServerForDimension(Settings.SPECTRE_DIMENSON_ID);
                 int coord = playerConnection.get(cubeOwner);
-
                 if (operator.dimension != Settings.SPECTRE_DIMENSON_ID) {
                     MinecraftServer.getServer().getConfigurationManager().transferPlayerToDimension(
                             (EntityPlayerMP) operator,
                             Settings.SPECTRE_DIMENSON_ID,
-                            new TeleporterSpectre(spectreWorld));
+                            new TeleporterSpectre(spectreWorld, coord));
                 }
-
-                operator.setPositionAndUpdate(coord * 32 + 9 - 1, 42, 2 - 0.5);
             }
         }
     }
 
     public void teleportPlayerToSpectreWorld(EntityPlayerMP player) {
-        String playerName = player.getCommandSenderName();
-        int coord;
-        WorldServer spectreWorld = MinecraftServer.getServer().worldServerForDimension(Settings.SPECTRE_DIMENSON_ID);
+        final String playerName = player.getCommandSenderName();
+        final int coord;
+        final WorldServer spectreWorld = MinecraftServer.getServer()
+                .worldServerForDimension(Settings.SPECTRE_DIMENSON_ID);
         if (playerConnection.containsKey(playerName)) {
             coord = playerConnection.get(playerName);
         } else {
             coord = nextCoord;
             nextCoord++;
-            WorldUtils.generateCube(
-                    spectreWorld,
-                    coord * 32,
-                    40,
-                    0,
-                    coord * 32 + 15,
-                    52,
-                    15,
-                    ModBlocks.spectreBlock,
-                    12,
-                    2);
             playerConnection.put(playerName, coord);
             this.markDirty();
         }
@@ -102,10 +87,8 @@ public class SpectreHandler extends WorldSavedData {
             MinecraftServer.getServer().getConfigurationManager().transferPlayerToDimension(
                     player,
                     Settings.SPECTRE_DIMENSON_ID,
-                    new TeleporterSpectre(spectreWorld));
+                    new TeleporterSpectre(spectreWorld, coord));
         }
-
-        player.setPositionAndUpdate(coord * 32 + 9 - 1, 42, 2 - 0.5);
     }
 
     @Override

--- a/src/main/java/lumien/randomthings/Handler/Spectre/SpectreHandler.java
+++ b/src/main/java/lumien/randomthings/Handler/Spectre/SpectreHandler.java
@@ -11,7 +11,6 @@ import net.minecraft.potion.PotionEffect;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.ChatComponentText;
-import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldSavedData;
@@ -51,6 +50,7 @@ public class SpectreHandler extends WorldSavedData {
     }
 
     public void sendOperator(EntityPlayer operator, String cubeOwner) {
+        if (operator.dimension == Settings.SPECTRE_DIMENSON_ID) return;
         if (MinecraftServer.getServer().getConfigurationManager().func_152596_g(operator.getGameProfile())) {
             if (!playerConnection.containsKey(cubeOwner)) {
                 operator.addChatComponentMessage(
@@ -59,17 +59,17 @@ public class SpectreHandler extends WorldSavedData {
                 WorldServer spectreWorld = MinecraftServer.getServer()
                         .worldServerForDimension(Settings.SPECTRE_DIMENSON_ID);
                 int coord = playerConnection.get(cubeOwner);
-                if (operator.dimension != Settings.SPECTRE_DIMENSON_ID) {
-                    MinecraftServer.getServer().getConfigurationManager().transferPlayerToDimension(
-                            (EntityPlayerMP) operator,
-                            Settings.SPECTRE_DIMENSON_ID,
-                            new TeleporterSpectre(spectreWorld, coord));
-                }
+                MinecraftServer.getServer().getConfigurationManager().transferPlayerToDimension(
+                        (EntityPlayerMP) operator,
+                        Settings.SPECTRE_DIMENSON_ID,
+                        new TeleporterSpectre(spectreWorld, coord));
             }
         }
     }
 
     public void teleportPlayerToSpectreWorld(EntityPlayerMP player) {
+        if (player.dimension == Settings.SPECTRE_DIMENSON_ID) return;
+
         final String playerName = player.getCommandSenderName();
         final int coord;
         final WorldServer spectreWorld = MinecraftServer.getServer()
@@ -83,12 +83,10 @@ public class SpectreHandler extends WorldSavedData {
             this.markDirty();
         }
 
-        if (player.dimension != Settings.SPECTRE_DIMENSON_ID) {
-            MinecraftServer.getServer().getConfigurationManager().transferPlayerToDimension(
-                    player,
-                    Settings.SPECTRE_DIMENSON_ID,
-                    new TeleporterSpectre(spectreWorld, coord));
-        }
+        MinecraftServer.getServer().getConfigurationManager().transferPlayerToDimension(
+                player,
+                Settings.SPECTRE_DIMENSON_ID,
+                new TeleporterSpectre(spectreWorld, coord));
     }
 
     @Override
@@ -152,25 +150,19 @@ public class SpectreHandler extends WorldSavedData {
     public void teleportPlayerOutOfSpectreWorld(EntityPlayerMP player) {
         if (((EntityAccessor) player).getCustomEntityData() != null) {
             NBTTagCompound nbt = player.getEntityData();
-            if (nbt.hasKey(RandomThingsNBTKeys.OLD_POSX)) {
+            if (nbt.hasKey(RandomThingsNBTKeys.OLD_DIMENSION)) {
                 int oldDimension = nbt.getInteger(RandomThingsNBTKeys.OLD_DIMENSION);
-                double oldPosX = nbt.getDouble(RandomThingsNBTKeys.OLD_POSX);
-                double oldPosY = nbt.getDouble(RandomThingsNBTKeys.OLD_POSY);
-                double oldPosZ = nbt.getDouble(RandomThingsNBTKeys.OLD_POSZ);
                 MinecraftServer.getServer().getConfigurationManager().transferPlayerToDimension(
                         player,
                         oldDimension,
                         new TeleporterSpectre(MinecraftServer.getServer().worldServerForDimension(oldDimension)));
-                player.setPositionAndUpdate(oldPosX, oldPosY, oldPosZ);
                 return;
             }
         }
-        ChunkCoordinates cc = MinecraftServer.getServer().worldServerForDimension(0).provider.getRandomizedSpawnPoint();
         MinecraftServer.getServer().getConfigurationManager().transferPlayerToDimension(
                 player,
                 0,
                 new TeleporterSpectre(MinecraftServer.getServer().worldServerForDimension(0)));
-        player.setPositionAndUpdate(cc.posX, cc.posY, cc.posZ);
     }
 
     public void update() {
@@ -178,7 +170,6 @@ public class SpectreHandler extends WorldSavedData {
             for (int i = 0; i < worldObj.playerEntities.size(); i++) {
                 if (worldObj.playerEntities.get(i) instanceof EntityPlayer) {
                     EntityPlayer player = (EntityPlayer) worldObj.playerEntities.get(i);
-
                     if (!MinecraftServer.getServer().getConfigurationManager().func_152596_g(player.getGameProfile())) {
                         String username = player.getCommandSenderName();
                         if (playerConnection.containsKey(username)) {
@@ -190,14 +181,10 @@ public class SpectreHandler extends WorldSavedData {
                                 player.addPotionEffect(new PotionEffect(PotionEffects.SLOWNESS, 200, 5, false));
                             }
                         } else {
-                            ChunkCoordinates cc = MinecraftServer.getServer().worldServerForDimension(0).provider
-                                    .getRandomizedSpawnPoint();
                             MinecraftServer.getServer().getConfigurationManager().transferPlayerToDimension(
                                     (EntityPlayerMP) player,
                                     0,
                                     new TeleporterSpectre(MinecraftServer.getServer().worldServerForDimension(0)));
-
-                            player.setPositionAndUpdate(cc.posX, cc.posY, cc.posZ);
                         }
                     }
                 }

--- a/src/main/java/lumien/randomthings/Handler/Spectre/SpectreHandler.java
+++ b/src/main/java/lumien/randomthings/Handler/Spectre/SpectreHandler.java
@@ -179,26 +179,15 @@ public class SpectreHandler extends WorldSavedData {
                         oldDimension,
                         new TeleporterSpectre(MinecraftServer.getServer().worldServerForDimension(oldDimension)));
                 player.setPositionAndUpdate(oldPosX, oldPosY, oldPosZ);
-            } else {
-                ChunkCoordinates cc = MinecraftServer.getServer().worldServerForDimension(0).provider
-                        .getRandomizedSpawnPoint();
-                MinecraftServer.getServer().getConfigurationManager().transferPlayerToDimension(
-                        player,
-                        0,
-                        new TeleporterSpectre(MinecraftServer.getServer().worldServerForDimension(0)));
-
-                player.setPositionAndUpdate(cc.posX, cc.posY, cc.posZ);
+                return;
             }
-        } else {
-            ChunkCoordinates cc = MinecraftServer.getServer().worldServerForDimension(0).provider
-                    .getRandomizedSpawnPoint();
-            MinecraftServer.getServer().getConfigurationManager().transferPlayerToDimension(
-                    player,
-                    0,
-                    new TeleporterSpectre(MinecraftServer.getServer().worldServerForDimension(0)));
-
-            player.setPositionAndUpdate(cc.posX, cc.posY, cc.posZ);
         }
+        ChunkCoordinates cc = MinecraftServer.getServer().worldServerForDimension(0).provider.getRandomizedSpawnPoint();
+        MinecraftServer.getServer().getConfigurationManager().transferPlayerToDimension(
+                player,
+                0,
+                new TeleporterSpectre(MinecraftServer.getServer().worldServerForDimension(0)));
+        player.setPositionAndUpdate(cc.posX, cc.posY, cc.posZ);
     }
 
     public void update() {

--- a/src/main/java/lumien/randomthings/Handler/Spectre/TeleporterSpectre.java
+++ b/src/main/java/lumien/randomthings/Handler/Spectre/TeleporterSpectre.java
@@ -4,12 +4,47 @@ import net.minecraft.entity.Entity;
 import net.minecraft.world.Teleporter;
 import net.minecraft.world.WorldServer;
 
+import lumien.randomthings.Blocks.ModBlocks;
+import lumien.randomthings.Configuration.Settings;
+
 public class TeleporterSpectre extends Teleporter {
 
-    public TeleporterSpectre(WorldServer par1WorldServer) {
-        super(par1WorldServer);
+    private final WorldServer world;
+    private final int coord;
+
+    public TeleporterSpectre(WorldServer world) {
+        super(world);
+        this.world = world;
+        this.coord = 0;
+    }
+
+    public TeleporterSpectre(WorldServer world, int coord) {
+        super(world);
+        this.world = world;
+        this.coord = coord;
     }
 
     @Override
-    public void placeInPortal(Entity par1Entity, double par2, double par4, double par6, float par8) {}
+    public void placeInPortal(Entity entity, double par2, double par4, double par6, float par8) {
+        if (this.world.provider.dimensionId == Settings.SPECTRE_DIMENSON_ID) {
+            final int minX = Math.min(coord * 32, coord * 32 + 15);
+            final int minY = 40;
+            final int minZ = 0;
+
+            final int maxX = Math.max(coord * 32, coord * 32 + 15);
+            final int maxY = 52;
+            final int maxZ = 15;
+
+            for (int x = minX; x <= maxX; x++) {
+                for (int y = minY; y <= maxY; y++) {
+                    for (int z = minZ; z <= maxZ; z++) {
+                        if (x == minX || y == minY || z == minZ || x == maxX || y == maxY || z == maxZ) {
+                            this.world.setBlock(x, y, z, ModBlocks.spectreBlock, 12, 2);
+                        }
+                    }
+                }
+            }
+            entity.setLocationAndAngles(coord * 32 + 9 - 1, 42, 2 - 0.5, entity.rotationYaw, 0.0F);
+        }
+    }
 }

--- a/src/main/java/lumien/randomthings/Handler/Spectre/TeleporterSpectre.java
+++ b/src/main/java/lumien/randomthings/Handler/Spectre/TeleporterSpectre.java
@@ -32,11 +32,12 @@ public class TeleporterSpectre extends Teleporter {
     public void placeInPortal(Entity entity, double par2, double par4, double par6, float par8) {
         if (this.world.provider.dimensionId == Settings.SPECTRE_DIMENSON_ID) {
 
+            final double movementFactor = entity.worldObj.provider.getMovementFactor();
             final NBTTagCompound nbt = entity.getEntityData();
             nbt.setInteger(RandomThingsNBTKeys.OLD_DIMENSION, entity.worldObj.provider.dimensionId);
-            nbt.setDouble(RandomThingsNBTKeys.OLD_POSX, entity.posX);
+            nbt.setDouble(RandomThingsNBTKeys.OLD_POSX, entity.posX / movementFactor);
             nbt.setDouble(RandomThingsNBTKeys.OLD_POSY, entity.posY);
-            nbt.setDouble(RandomThingsNBTKeys.OLD_POSZ, entity.posZ);
+            nbt.setDouble(RandomThingsNBTKeys.OLD_POSZ, entity.posZ / movementFactor);
 
             final int minX = Math.min(coord * 32, coord * 32 + 15);
             final int minY = 40;

--- a/src/main/java/lumien/randomthings/Handler/Spectre/TeleporterSpectre.java
+++ b/src/main/java/lumien/randomthings/Handler/Spectre/TeleporterSpectre.java
@@ -1,11 +1,15 @@
 package lumien.randomthings.Handler.Spectre;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.world.Teleporter;
 import net.minecraft.world.WorldServer;
 
 import lumien.randomthings.Blocks.ModBlocks;
 import lumien.randomthings.Configuration.Settings;
+import lumien.randomthings.Library.RandomThingsNBTKeys;
+import lumien.randomthings.Mixins.early.EntityAccessor;
 
 public class TeleporterSpectre extends Teleporter {
 
@@ -27,6 +31,13 @@ public class TeleporterSpectre extends Teleporter {
     @Override
     public void placeInPortal(Entity entity, double par2, double par4, double par6, float par8) {
         if (this.world.provider.dimensionId == Settings.SPECTRE_DIMENSON_ID) {
+
+            final NBTTagCompound nbt = entity.getEntityData();
+            nbt.setInteger(RandomThingsNBTKeys.OLD_DIMENSION, entity.worldObj.provider.dimensionId);
+            nbt.setDouble(RandomThingsNBTKeys.OLD_POSX, entity.posX);
+            nbt.setDouble(RandomThingsNBTKeys.OLD_POSY, entity.posY);
+            nbt.setDouble(RandomThingsNBTKeys.OLD_POSZ, entity.posZ);
+
             final int minX = Math.min(coord * 32, coord * 32 + 15);
             final int minY = 40;
             final int minZ = 0;
@@ -46,7 +57,24 @@ public class TeleporterSpectre extends Teleporter {
                     }
                 }
             }
+
             entity.setLocationAndAngles(coord * 32 + 9 - 1, 42, 2 - 0.5, entity.rotationYaw, 0.0F);
+
+        } else {
+
+            if (((EntityAccessor) entity).getCustomEntityData() != null) {
+                NBTTagCompound nbt = entity.getEntityData();
+                if (nbt.hasKey(RandomThingsNBTKeys.OLD_POSX)) {
+                    double oldPosX = nbt.getDouble(RandomThingsNBTKeys.OLD_POSX);
+                    double oldPosY = nbt.getDouble(RandomThingsNBTKeys.OLD_POSY);
+                    double oldPosZ = nbt.getDouble(RandomThingsNBTKeys.OLD_POSZ);
+                    entity.setLocationAndAngles(oldPosX, oldPosY, oldPosZ, entity.rotationYaw, 0.0F);
+                    return;
+                }
+            }
+            ChunkCoordinates cc = this.world.provider.getRandomizedSpawnPoint();
+            entity.setLocationAndAngles(cc.posX, cc.posY, cc.posZ, entity.rotationYaw, 0.0F);
+
         }
     }
 }

--- a/src/main/java/lumien/randomthings/Handler/Spectre/TeleporterSpectre.java
+++ b/src/main/java/lumien/randomthings/Handler/Spectre/TeleporterSpectre.java
@@ -39,7 +39,9 @@ public class TeleporterSpectre extends Teleporter {
                 for (int y = minY; y <= maxY; y++) {
                     for (int z = minZ; z <= maxZ; z++) {
                         if (x == minX || y == minY || z == minZ || x == maxX || y == maxY || z == maxZ) {
-                            this.world.setBlock(x, y, z, ModBlocks.spectreBlock, 12, 2);
+                            if (this.world.getBlock(x, y, z) != ModBlocks.spectreBlock) {
+                                this.world.setBlock(x, y, z, ModBlocks.spectreBlock, 12, 2);
+                            }
                         }
                     }
                 }

--- a/src/main/java/lumien/randomthings/Items/ItemSpectreKey.java
+++ b/src/main/java/lumien/randomthings/Items/ItemSpectreKey.java
@@ -68,15 +68,15 @@ public class ItemSpectreKey extends ItemBase {
     }
 
     @Override
-    public ItemStack onEaten(ItemStack par1ItemStack, World par2World, EntityPlayer par3EntityPlayer) {
-        if (!par2World.isRemote) {
-            if (par2World.provider.dimensionId != Settings.SPECTRE_DIMENSON_ID) {
-                RandomThings.instance.spectreHandler.teleportPlayerToSpectreWorld((EntityPlayerMP) par3EntityPlayer);
+    public ItemStack onEaten(ItemStack stack, World world, EntityPlayer entity) {
+        if (!world.isRemote) {
+            if (world.provider.dimensionId != Settings.SPECTRE_DIMENSON_ID) {
+                RandomThings.instance.spectreHandler.teleportPlayerToSpectreWorld((EntityPlayerMP) entity);
             } else {
-                RandomThings.instance.spectreHandler.teleportPlayerOutOfSpectreWorld((EntityPlayerMP) par3EntityPlayer);
+                RandomThings.instance.spectreHandler.teleportPlayerOutOfSpectreWorld((EntityPlayerMP) entity);
             }
         }
-        return par1ItemStack;
+        return stack;
     }
 
     @Override

--- a/src/main/java/lumien/randomthings/Library/WorldUtils.java
+++ b/src/main/java/lumien/randomthings/Library/WorldUtils.java
@@ -110,27 +110,6 @@ public class WorldUtils {
         worldObj.notifyBlocksOfNeighborChange(posX, posY, posZ + 1, block);
     }
 
-    public static void generateCube(World worldObj, int posX1, int posY1, int posZ1, int posX2, int posY2, int posZ2,
-            Block b, int metadata, int flag) {
-        int minX = Math.min(posX1, posX2);
-        int minY = Math.min(posY1, posY2);
-        int minZ = Math.min(posZ1, posZ2);
-
-        int maxX = Math.max(posX1, posX2);
-        int maxY = Math.max(posY1, posY2);
-        int maxZ = Math.max(posZ1, posZ2);
-
-        for (int x = minX; x <= maxX; x++) {
-            for (int y = minY; y <= maxY; y++) {
-                for (int z = minZ; z <= maxZ; z++) {
-                    if (x == minX || y == minY || z == minZ || x == maxX || y == maxY || z == maxZ) {
-                        worldObj.setBlock(x, y, z, b, metadata, flag);
-                    }
-                }
-            }
-        }
-    }
-
     public static boolean isPlayerOnline(String username) {
         if (FMLCommonHandler.instance().getEffectiveSide().isServer()) {
             return MinecraftServer.getServer().getConfigurationManager().func_152612_a(username) != null;


### PR DESCRIPTION
With the chunk scheduler changes in hodgepodge it would not generate the cube when teleporting to the spectre dimension which means that you just fall in the void to your death.

I fixed it by moving the cube generation code inside the Teleporter method and I also changed it to generate the cube everytime you teleport not only on the first teleport.