### PR TITLE
Remove GL calls in SpectreGlass getRenderColor

### DIFF
--- a/src/main/java/lumien/randomthings/Blocks/Spectre/BlockSpectreGlass.java
+++ b/src/main/java/lumien/randomthings/Blocks/Spectre/BlockSpectreGlass.java
@@ -11,8 +11,6 @@ import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
 
-import org.lwjgl.opengl.GL11;
-
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import lumien.randomthings.Blocks.BlockBase;
@@ -38,8 +36,6 @@ public class BlockSpectreGlass extends BlockBase {
 
     @Override
     public int getRenderColor(int p_149741_1_) {
-        GL11.glEnable(GL11.GL_BLEND);
-        GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
         return 16777215;
     }
 


### PR DESCRIPTION
I got no idea why these are here. Tested it out and the glass still looks/works the exact same way

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25519
Closes https://github.com/GTNewHorizons/Angelica/issues/1813