### PR TITLE
fix: use renderViewEntity for camera math

### DIFF
--- a/src/main/java/lumien/randomthings/Handler/RTEventHandler.java
+++ b/src/main/java/lumien/randomthings/Handler/RTEventHandler.java
@@ -117,9 +117,10 @@ public class RTEventHandler {
                 DimensionCoordinate pos = ItemFilter.getPosition(item);
 
                 if (player.dimension == pos.dimension) {
-                    double playerX = player.prevPosX + (player.posX - player.prevPosX) * event.partialTicks;
-                    double playerY = player.prevPosY + (player.posY - player.prevPosY) * event.partialTicks;
-                    double playerZ = player.prevPosZ + (player.posZ - player.prevPosZ) * event.partialTicks;
+                    EntityLivingBase viewEntity = mc.renderViewEntity != null ? mc.renderViewEntity : player;
+                    double playerX = viewEntity.prevPosX + (viewEntity.posX - viewEntity.prevPosX) * event.partialTicks;
+                    double playerY = viewEntity.prevPosY + (viewEntity.posY - viewEntity.prevPosY) * event.partialTicks;
+                    double playerZ = viewEntity.prevPosZ + (viewEntity.posZ - viewEntity.prevPosZ) * event.partialTicks;
 
                     RenderUtils.enableDefaultBlending();
 


### PR DESCRIPTION
## Summary
Freecam compat - use renderViewEntity for camera math


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
